### PR TITLE
修改高能进度条url和参数

### DIFF
--- a/video/pbp.md
+++ b/video/pbp.md
@@ -6,15 +6,17 @@
 
 ## 获取弹幕趋势顶点列表
 
-> http://api.bilibili.com/pbp/data
+> http://bvc.bilivideo.com/pbp/data
 
 *请求方式：GET*
 
 **url参数：**
 
-| 参数名 | 类型 | 内容    | 必要性 | 备注 |
-| ------ | ---- | ------- | ------ | ---- |
-| vid    | num  | 视频CID | 必要   |      |
+| 参数名 | 类型 | 内容     | 必要性 | 备注 |
+| ------ | ---- | -------- | ------ | ---- |
+| cid    | num  | 视频CID  | 必要   |      |
+| aid    | num  | 稿件avID | 非必要 |      |
+| bvid   | num  | 稿件bvID | 非必要 |      |
 
 **json回复：**
 


### PR DESCRIPTION
似乎原来的http://api.bilibili.com/pbp/data 已经挂了
在视频中一般是这样请求的：
https://bvc.bilivideo.com/pbp/data?r=loader&cid=186803402&aid=412935552&bvid=BV1FV411d7u7&version=1.0.0&innersign=&mid=160148624
带了r=loader会多返回一个js的链接和其他一些数据，更改version的值会使返回的tagstr有变化。
例：
```json
{
    "modules":[
        {
            "params":{
                "data":{
                    "step_sec":3,
                    "tagstr":"pbphide_0&client_1.0.0&innersign_0&group_eg&nocheck_0&version_&pbphide_0",
                    "events":{
                        "default":[
                            ...
                        ]
                    },
                    "debug":"{\"max_time\":233,\"zero_points_ratio\":0,\"total_dm\":1000,\"event_count\":2640427}"
                }
            },
            "script_src":"//i0.hdslb.com/bfs/static/pbp/pbp-3.5.2.min.js",
            "name":"pbp",
            "load_mode":"pbp",
            "version":"3.5.2"
        }
    ]
}
```