### PR TITLE
课程playUrl参数中的avid和cid多余

### DIFF
--- a/cheese/videostream_url.md
+++ b/cheese/videostream_url.md
@@ -23,9 +23,7 @@
 
 | 参数名 | 类型 | 内容           | 必要性 | 备注                                                         |
 | ------ | ---- | -------------- | ------ | ------------------------------------------------------------ |
-| avid   | num  | 课程avid       | 必要   |                                                              |
 | ep_id  | num  | 课程epid       | 必要   |                                                              |
-| cid    | num  | 视频cid        | 必要   |                                                              |
 | qn     | num  | 视频清晰度选择 | 非必要 | 参考[qn定义](../video/videostream_url.md#qn视频清晰度标识)   |
 | fnver  | num  | 视频流版本     | 非必要 | 参考[fnver定义](../video/videostream_url.md#fnver视频流版本标识) |
 | fnval  | num  | 视频流类型     | 非必要 | 参考[fnval定义](../video/videostream_url.md#fnval视频流格式标识) |


### PR DESCRIPTION
avid和cid不会被检查；如果只使用avid和cid而没有ep_id，则会收到 {'code': -400, 'message': '请求错误'}