### PR TITLE
修复两处导致Protobuf代码生成失败的Bug

### DIFF
--- a/grpc_api/bilibili/gaia/gw/gw_api.proto
+++ b/grpc_api/bilibili/gaia/gw/gw_api.proto
@@ -2,9 +2,7 @@ syntax = "proto3";
 
 package bilibili.gaia.gw;
 
-import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 import "google/protobuf/empty.proto";
-//import "extension/wdcli/wdcli.proto";
 
 // 应用列表上报
 service Gaia {

--- a/grpc_api/bilibili/main/common/arch/doll/v1/doll.proto
+++ b/grpc_api/bilibili/main/common/arch/doll/v1/doll.proto
@@ -14,7 +14,7 @@ service Echo {
 
 //
 message PingRequest {
-    /
+    //
     int64  time = 1;
 }
 


### PR DESCRIPTION
测试生成命令:

```python
mkdir grpc_api/pycode
protoc -I grpc_api/ --python_out=grpc_api/pycode $(find grpc_api/ | grep ".proto")
```