### PR TITLE
Fix gRPC `bilibili.app.interfaces.v1.OfficialVerify` duplicate definition

### DIFF
--- a/grpc_api/bilibili/app/interfaces/v1/space.proto
+++ b/grpc_api/bilibili/app/interfaces/v1/space.proto
@@ -37,14 +37,6 @@ enum From {
 }
 
 //
-message OfficialVerify {
-    //
-    int32 type = 1;
-    //
-    string desc = 2;
-}
-
-//
 message SearchTabReply {
     //
     int64 focus = 1;


### PR DESCRIPTION
```
bilibili/app/interfaces/v1/space.proto:42:11: "bilibili.app.interfaces.v1.OfficialVerify.type" is already defined in file "bilibili/app/interfaces/v1/search.proto".
bilibili/app/interfaces/v1/space.proto:44:12: "bilibili.app.interfaces.v1.OfficialVerify.desc" is already defined in file "bilibili/app/interfaces/v1/search.proto".
bilibili/app/interfaces/v1/space.proto:40:9: "bilibili.app.interfaces.v1.OfficialVerify" is already defined in file "bilibili/app/interfaces/v1/search.proto".
```