### PR TITLE
Fix gRPC `gpc.gaetway.vega.v1.Status` not defined

### DIFF
--- a/grpc_api/pgc/gaetway/vega/v1/vega.proto
+++ b/grpc_api/pgc/gaetway/vega/v1/vega.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package pgc.gateway.vega.v1;
 
+import "bilibili/rpc/status.proto";
 import "google/protobuf/any.proto";
 import "google/protobuf/empty.proto";
 
@@ -44,7 +45,7 @@ message FrameOption {
     //
     bool is_ack = 4;
     //
-    Status status = 5;
+    bilibili.rpc.Status status = 5;
     //
     string ack_origin = 6;
     //


### PR DESCRIPTION
```
pgc/gaetway/vega/v1/vega.proto:47:5: "Status" is not defined.
```