### PR TITLE
fix: markdown rendering error caused by unescaped '|'

### DIFF
--- a/login/login_action/SMS.md
+++ b/login/login_action/SMS.md
@@ -120,7 +120,7 @@ curl 'http://passport.bilibili.com/web/generic/country/list'
 | token | str  | 登录 API token | 必要 | 在[申请 captcha 验证码](readme.md#申请captcha验证码)接口处获取 |
 | challenge | str | 极验 challenge | 必要 | 在[申请 captcha 验证码](readme.md#申请captcha验证码)接口处获取 |
 | validate | str | 极验 result | 必要 | 极验验证后得到 |
-| seccode | str | 极验 result +`|jordan` | 必要   | 极验验证后得到 |
+| seccode | str | 极验 result +`\|jordan` | 必要   | 极验验证后得到 |
 
 **json回复：**
 

--- a/login/login_action/password.md
+++ b/login/login_action/password.md
@@ -105,7 +105,7 @@ curl 'http://passport.bilibili.com/x/passport-login/web/key'
 | token     | str  | 登录 token             | 必要   | 在[申请 captcha 验证码](readme.md#申请captcha验证码)接口处获取 |
 | challenge | str  | 极验 challenge         | 必要   | 在[申请 captcha 验证码](readme.md#申请captcha验证码)接口处获取 |
 | validate  | str  | 极验 result            | 必要   | 极验验证后得到                                               |
-| seccode   | str  | 极验 result +`|jordan` | 必要   | 极验验证后得到                                               |
+| seccode   | str  | 极验 result +`\|jordan` | 必要   | 极验验证后得到                                               |
 | go_url    | str  | 跳转 url               | 非必要 | 默认为 https://www.bilibili.com                              |
 | source    | str  | 登录来源               | 非必要 | `main_web`：独立登录页<br />`main_mini`：小窗登录            |
 
@@ -253,7 +253,7 @@ curl 'http://passport.bilibili.com/login?act=getkey'
 | key         | str  | 登录 token             | 必要   | 在[申请 captcha 验证码](readme.md#申请captcha验证码)接口处获取 |
 | challenge   | str  | 极验 challenge         | 必要   | 在[申请 captcha 验证码](readme.md#申请captcha验证码)接口处获取 |
 | validate    | str  | 极验 result            | 必要   | 极验验证后得到                                               |
-| seccode     | str  | 极验 result +`|jordan` | 必要   | 极验验证后得到                                               |
+| seccode     | str  | 极验 result +`\|jordan` | 必要   | 极验验证后得到                                               |
 
 </details>    
 


### PR DESCRIPTION
`|jordan` 中的 `|` 标记被识别为制表标记，导致此行表格出现渲染错误