### PR TITLE
修复获取用户专栏信息的部分错误

### DIFF
--- a/article/list.md
+++ b/article/list.md
@@ -171,7 +171,7 @@
 | 字段名  | 类型  | 内容   | 备注  |
 |------|-----|------|-----|
 | tid  | num | 标签id |     |
-| name | num | 标签名称 |     |
+| name | str | 标签名称 |     |
 
 ### `data`对象 -> `articles`数组中的对象 -> `media`对象
 
@@ -444,7 +444,7 @@ curl -L -X GET 'https://api.bilibili.com/x/space/article?mid=300021061&pn=1&ps=2
 
 ## 获取用户专栏文集列表
 
-> http://api.bilibili.com/x/space/article
+> http://api.bilibili.com/x/article/up/lists
 
 *请求方式：GET*
 

--- a/article/list.md
+++ b/article/list.md
@@ -444,7 +444,7 @@ curl -L -X GET 'https://api.bilibili.com/x/space/article?mid=300021061&pn=1&ps=2
 
 ## 获取用户专栏文集列表
 
-> http://api.bilibili.com/x/article/up/lists
+> https://api.bilibili.com/x/article/up/lists
 
 *请求方式：GET*
 
@@ -500,7 +500,9 @@ curl -L -X GET 'https://api.bilibili.com/x/space/article?mid=300021061&pn=1&ps=2
 **示例：**
 
 ```shell
-curl -L -X GET 'https://api.bilibili.com/x/article/up/lists?mid=2859372&sort=0'
+curl -X GET 'https://api.bilibili.com/x/article/up/lists' \
+    --data-urlencode 'mid=2859372' \
+    --data-urlencode 'sort=0'
 ```
 
 <details>


### PR DESCRIPTION
1. `data`对象 -> `articles`数组中的对象 -> `tags`数组中的对象 -> `name`字段类型是`str`，写成了`num`
2. “获取用户专栏文集列表” 的url误填成了“获取用户专栏文章列表”的url