### PR TITLE
修改评论区相关说明

### DIFF
--- a/docs/comment/readme.md
+++ b/docs/comment/readme.md
@@ -70,7 +70,7 @@
 | folder        | obj                             | 折叠信息           |                                                              |
 | up_action     | obj                             | 评论 UP 主操作信息 |                                                              |
 | show_follow   | bool                            | (?)                |                                                              |
-| invisible     | bool                            |                    |                                                              |
+| invisible     | bool                            | 评论是否被隐藏      |                                                              |
 | card_label    | obj                             | 右上角卡片标签信息   |                                                              |
 | reply_control | obj                             | 评论提示文案信息   |                                                              |
 
@@ -334,3 +334,4 @@
 | sub_reply_entry_text | str  | 回复提示 | `共 xx 条回复`       |
 | sub_reply_title_text | str  | 回复提示 | `相关回复共有 xx 条` |
 | time_desc            | str  | 时间提示 | `xx 天/小时 前发布`  |
+| location             | str  | IP属地  | `IP属地：xx`        |


### PR DESCRIPTION
逆向b站前端的时候发现invisible为true的时候，前端的代码会故意不创建评论元素，但invisible为true的评论后端依然会正常返回评论的内容，相关的屏蔽是前端做的 经过简单的测试发现，当评论没有被删除，并且评论者本人被UP主拉黑时，invisible会为true

在2022-07-25 11:00及以后发布的评论会附带评论者当时的IP地址属地，现在b站网页端的API也会返回该属性，只是前端没有进行解析（不管是网页端新版还是旧版界面都有专门为IP属地元素设置对应的css样式，甚至旧版界面脚本里仅仅是把创建IP属地的元素注释掉了，去掉注释即可正常使用）

基于以上两点可以做出显示隐藏评论和网页端IP属地显示脚本，比如我整的[这个](https://github.com/LightQuanta/BilibiliEnhance)（