### PR TITLE
修复gRPC协议文件的一些错误

### DIFF
--- a/grpc_api/bilibili/app/distribution/v1/distribution.proto
+++ b/grpc_api/bilibili/app/distribution/v1/distribution.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package bilibili.app.distribution.v1;
 
+import "google/protobuf/any.proto";
+
 // APP配置
 service Distribution {
     // 获取云端储存的用户偏好

--- a/grpc_api/bilibili/app/dynamic/v2/campus.proto
+++ b/grpc_api/bilibili/app/dynamic/v2/campus.proto
@@ -9,7 +9,7 @@ import "bilibili/app/dynamic/common/dynamic.proto";
 import "bilibili/app/dynamic/v2/dynamic.proto";
 
 service Campus {
-    // WaterFlowRcmdReply 暂未定义
+    // 
     rpc WaterFlowRcmd (WaterFlowRcmdReq) returns (WaterFlowRcmdReply);
 }
 

--- a/grpc_api/bilibili/app/dynamic/v2/campus.proto
+++ b/grpc_api/bilibili/app/dynamic/v2/campus.proto
@@ -10,7 +10,7 @@ import "bilibili/app/dynamic/v2/dynamic.proto";
 
 service Campus {
     // 
-    rpc WaterFlowRcmd (WaterFlowRcmdReq) returns (WaterFlowRcmdReply);
+    rpc WaterFlowRcmd (WaterFlowRcmdReq) returns (WaterFlowRcmdResp);
 }
 
 // 

--- a/grpc_api/bilibili/app/dynamic/v2/campus.proto
+++ b/grpc_api/bilibili/app/dynamic/v2/campus.proto
@@ -9,7 +9,7 @@ import "bilibili/app/dynamic/common/dynamic.proto";
 import "bilibili/app/dynamic/v2/dynamic.proto";
 
 service Campus {
-    // 
+    // WaterFlowRcmdReply 暂未定义
     rpc WaterFlowRcmd (WaterFlowRcmdReq) returns (WaterFlowRcmdReply);
 }
 

--- a/grpc_api/bilibili/app/dynamic/v2/dynamic.proto
+++ b/grpc_api/bilibili/app/dynamic/v2/dynamic.proto
@@ -780,7 +780,7 @@ message CampusHomePagesReq {
     // 
     double lng = 4;
     // 
-    PlayerArgs player_args = 5;
+    bilibili.app.archive.middleware.v1.PlayerArgs player_args = 5;
     // 
     int32 page_type = 6;
 }

--- a/grpc_api/bilibili/app/interfaces/v1/history.proto
+++ b/grpc_api/bilibili/app/interfaces/v1/history.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package bilibili.app.interfaces.v1;
+package bilibili.app.interface.v1;
 
 import "bilibili/app/archive/middleware/v1/preload.proto";
 

--- a/grpc_api/bilibili/app/interfaces/v1/media.proto
+++ b/grpc_api/bilibili/app/interfaces/v1/media.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package bilibili.app.interfaces.v1;
+package bilibili.app.interface.v1;
 
 //
 service Media {

--- a/grpc_api/bilibili/app/interfaces/v1/search.proto
+++ b/grpc_api/bilibili/app/interfaces/v1/search.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package bilibili.app.interfaces.v1;
+package bilibili.app.interface.v1;
 
 // 搜索
 service Search {

--- a/grpc_api/bilibili/app/interfaces/v1/space.proto
+++ b/grpc_api/bilibili/app/interfaces/v1/space.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package bilibili.app.interfaces.v1;
+package bilibili.app.interface.v1;
 
 import "bilibili/app/archive/middleware/v1/preload.proto";
 import "bilibili/app/archive/v1/archive.proto";

--- a/grpc_api/bilibili/app/listener/v1/listener.proto
+++ b/grpc_api/bilibili/app/listener/v1/listener.proto
@@ -287,7 +287,7 @@ message DetailItem {
     //
     string history_tag = 13;
     //
-    bilibili.app.interfaces.v1.DeviceType device_type = 14;
+    bilibili.app.interface.v1.DeviceType device_type = 14;
     //
     FavFolder ugc_season_info = 15;
 }

--- a/grpc_api/bilibili/dagw/component/avatar/v1/avatar.proto
+++ b/grpc_api/bilibili/dagw/component/avatar/v1/avatar.proto
@@ -45,7 +45,7 @@ message Layer {
     //
     bool visible = 2;
     //
-    LayerGeneralSpec general_spec = 3;
+    bilibili.dagw.component.avatar.common.LayerGeneralSpec general_spec = 3;
     //
     LayerConfig layer_config = 4;
     //
@@ -61,7 +61,7 @@ message LayerConfig {
     //
     bool allow_over_paint = 3;
     //
-    MaskProperty layer_mask = 4;
+    bilibili.dagw.component.avatar.common.MaskProperty layer_mask = 4;
 }
 
 //
@@ -71,7 +71,7 @@ message LayerGroup {
     //
     repeated Layer layers = 2;
     //
-    MaskProperty group_mask = 3;
+    bilibili.dagw.component.avatar.common.MaskProperty group_mask = 3;
     //
     bool is_critical_group = 4;
 }
@@ -96,17 +96,17 @@ message LayerTagConfig {
 //
 message ResAnimation {
     //
-    ResourceSource webp_src = 1;
+    bilibili.dagw.component.avatar.common.ResourceSource webp_src = 1;
 }
 
 //
 message ResImage {
     //
-    ResourceSource image_src = 1;
+    bilibili.dagw.component.avatar.common.ResourceSource image_src = 1;
 }
 
 //
 message ResNativeDraw {
     //
-    ResourceSource draw_src = 1;
+    bilibili.dagw.component.avatar.common.ResourceSource draw_src = 1;
 }

--- a/grpc_api/bilibili/dagw/component/avatar/v1/plugin.proto
+++ b/grpc_api/bilibili/dagw/component/avatar/v1/plugin.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package bilibili.dagw.component.avatar.v1.plugin;
 
+import "bilibili/dagw/component/avatar/common/common.proto";
+
 //
 message CommentDoubleClickConfig {
     //
@@ -55,7 +57,7 @@ message LiveAnimeConfig {
 //
 message LiveAnimeItem {
     //
-    ColorConfig color = 1;
+    bilibili.dagw.component.avatar.common.ColorConfig color = 1;
     //
     double start_ratio = 2;
     //


### PR DESCRIPTION
在将协议文件转换成C#时发现一些错误，包括类型引用错误和包名拼写错误，提PR来修复一下

要注意的是，grpc_api\bilibili\app\dynamic\v2\campus.proto 这个协议文件中WaterFlowRcmdReply这个响应体是没有定义的，我这边没有做逆向所以不对此进行修复