### PR TITLE
增加 /x/v2/dm/web/seg.so 弹幕接口的认证说明

### DIFF
--- a/docs/danmaku/danmaku_proto.md
+++ b/docs/danmaku/danmaku_proto.md
@@ -13,6 +13,7 @@
 > https://i0.hdslb.com/bfs/dm/{data}.bin （BAS/代码弹幕专包）
 
 *请求方式：GET*
+*认证方式：半匿名（部分视频在无 Cookie: SESSDATA 时只返回部分弹幕）*
 
 此接口与漫画弹幕相同
 


### PR DESCRIPTION
对如 https://www.bilibili.com/bangumi/play/ss44991 这个视频时，获取弹幕的接口在没有 Cookie: SESSDATA 时只返回部分弹幕（约 1/10），原因不明