### PR TITLE
新增私信消息记录参数，新增青少年模式接口

### DIFF
--- a/docs/message/private_msg.md
+++ b/docs/message/private_msg.md
@@ -249,9 +249,11 @@ curl 'https://api.vc.bilibili.com/web_im/v1/web_im/send_msg' \
 | sender_device_id  | num  | 发送者设备 | 可选 | 1 |
 | talker_id   | num  | 聊天对象的UID | 必要 | -------------- |
 | session_type   | num  | 聊天对象的类型 | 必要 | 1为用户，2为粉丝团 |
-| size   | num  | 列出消息条数 | 可选 | 默认是20 |
+| size   | num  | 列出消息条数 | 可选 | 默认是20，最大为200 |
 | build   | num  | 未知 | 可选 | 默认是0 |
 | mobi_app   | str  | 设备 | 可选 | web |
+| begin_seqno   | num   | 开始的序列号 | 可选 | 默认0为全部 |
+| end_seqno   | num   | 结束的序列号 | 可选 | 默认0为全部 |
 
 **json回复：**
 

--- a/docs/misc/teenager_mode.md
+++ b/docs/misc/teenager_mode.md
@@ -1,0 +1,72 @@
+# 青少年模式
+## 开启/关闭
+> https://app.bilibili.com/x/v2/account/teenagers/update
+*请求方式：POST*
+此接口有设计缺陷，已提交过SRC，评价为：风险较低，不收
+认证方式：APP
+
+**POST参数：**
+
+| 参数名    | 类型  | 内容    | 必要性     | 备注  |
+|--------|-----|-------|---------|-----|
+| appkey | str | APP密钥 | APP必要 |     |
+| ts     | num | 当前时间戳 | APP必要 |     |
+| sign   | str | APP签名 | APP必要 |     |
+| access_key   | str |  APP登录Token | APP必要 |     |
+| device_model   | str | 设备 Model | APP必要 |     |
+| channel | str | APP下载渠道 | APP必要 | 比如yingyongbao |
+| mobi_app | str |APP 包类型 | APP必要 |  |
+| platform | str |平台类型| APP必要 | android |
+| c_locale | str |语言| 非必要 | zh_CN |
+| s_locale | str |语言| 非必要 | zh_CN |
+| statistics | str | ? | 必要 | 一般固定为{"appId":1,"platform":3,"version":"7.27.0","abtest":""},非key-value入参需要转URL编码 |
+| pwd | num |密码| 必要 | 开启时为4位，关闭时必须为空 |
+| teenagers_mode | num |开启/关闭模式| 必要 | 0为开启，1为关闭 |
+| teenagers_status | num |当前模式状态| 必要 | 0为已经开启，1为目前关闭 |
+
+**json回复：**
+
+根对象：
+
+| 字段    | 类型   | 内容     | 备注                         |
+| ------- | ------ | -------- | ---------------------------- |
+| code    | num    | 返回值   | 0：成功 <br />-400：请求错误 |
+| message | str    | 错误信息 | 默认为0                      |
+| ttl     | num    | 1        |                  |
+
+**示例：**
+关闭本账号的青少年模式（pwd=&teenagers_mode=1&teenagers_status=0）
+
+curl --location 'https://app.bilibili.com/x/v2/account/teenagers/update' \
+--header 'Device-Id: 你的设备id' \
+--header 'Fp_local: ' \
+--header 'Fp_remote: ' \
+--header 'Session_id: 会话id' \
+--header 'App-Key: android' \
+--header 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' \
+--data-urlencode 'access_key=你的access_key' \
+--data-urlencode 'appkey=1d8b6e7d45233436' \
+--data-urlencode 'build=6270200' \
+--data-urlencode 'c_locale=zh_CN' \
+--data-urlencode 'channel=yingyongbao' \
+--data-urlencode 'device_model=samsung%257CSM-G955N' \
+--data-urlencode 'mobi_app=android' \
+--data-urlencode 'platform=android' \
+--data-urlencode 's_locale=zh_CN' \
+--data-urlencode 'statistics=%257B%2522appId%2522%253A1%252C%2522platform%2522%253A3%252C%2522version%2522%253A%25226.27.0%2522%252C%2522abtest%2522%253A%2522%2522%257D' \
+--data-urlencode 'pwd=' \
+--data-urlencode 'teenagers_mode=1' \
+--data-urlencode 'teenagers_status=0' \
+--data-urlencode 'ts=1699301298' \
+--data-urlencode 'sign=0666c38cb79691c4a0d9570a0669ec96' \
+
+<details>
+<summary>查看响应示例：</summary>
+```json
+{"code":0,
+"message":"0",
+"ttl":1
+}
+```
+
+</details>

--- a/docs/misc/teenager_mode.md
+++ b/docs/misc/teenager_mode.md
@@ -1,8 +1,10 @@
 # 青少年模式
 ## 开启/关闭
 > https://app.bilibili.com/x/v2/account/teenagers/update
+
 *请求方式：POST*
-此接口有设计缺陷，已提交过SRC，评价为：风险较低，不收
+
+此接口有设计缺陷，已提交过SRC，评价为：风险较低，不收</br>
 认证方式：APP
 
 **POST参数：**
@@ -36,7 +38,7 @@
 
 **示例：**
 关闭本账号的青少年模式（pwd=&teenagers_mode=1&teenagers_status=0）
-
+```shell
 curl --location 'https://app.bilibili.com/x/v2/account/teenagers/update' \
 --header 'Device-Id: 你的设备id' \
 --header 'Fp_local: ' \
@@ -59,13 +61,24 @@ curl --location 'https://app.bilibili.com/x/v2/account/teenagers/update' \
 --data-urlencode 'teenagers_status=0' \
 --data-urlencode 'ts=1699301298' \
 --data-urlencode 'sign=0666c38cb79691c4a0d9570a0669ec96' \
+```
 
 <details>
 <summary>查看响应示例：</summary>
+  
 ```json
-{"code":0,
-"message":"0",
-"ttl":1
+{
+    "code": 0,
+    "message": "0",
+    "ttl": 1
+}
+```
+pwd有数值时
+```json
+{
+    "code": -400,
+    "message": "关闭时密码必须为空",
+    "ttl": 1
 }
 ```
 


### PR DESCRIPTION
RT
私信消息记录新增了两个参数，更方便的控制想要查询的时间区间了
同时，新增了青少年模式接口，不知道放在哪，就放在其他分类里了，该接口存在逻辑bug，关闭时无需提交pwd，以至于这个功能本身就没有意义（甚至在关闭时接口不允许pwd有值），已上交过src，反馈为 经过内部沟通确认，此问题风险较低，忽略处理。
