### PR TITLE
[gRPC] 补充搜索子区直播信息定义

### DIFF
--- a/grpc_api/bilibili/polymer/app/search/v1/search.proto
+++ b/grpc_api/bilibili/polymer/app/search/v1/search.proto
@@ -531,6 +531,8 @@ message Item {
         SearchBangumiCard bangumi = 38;
         //
         SearchSportInlineCard esports_inline = 39;
+        //
+        SearchLiveRoom live_room = 50;
     }
 }
 

--- a/grpc_api/bilibili/polymer/app/search/v1/search.proto
+++ b/grpc_api/bilibili/polymer/app/search/v1/search.proto
@@ -1393,6 +1393,38 @@ message SearchLiveCard {
 }
 
 //
+message SearchLiveRoom {
+    //
+    string title = 1;
+    //
+    string name = 2;
+    //
+    string cover = 3;
+    //
+    string uri = 4;
+    //
+    string param = 5;
+    //
+    WatchedShow watched_show = 6;
+    //
+    int64 room_id = 7;
+    //
+    string short_id = 8;
+    //
+    string goto = 9;
+    //
+    string area_v2_name = 10;
+    //
+    int32 online = 11;
+    //
+    int64 mid = 12;
+    //
+    int32 live_status = 13;
+    //
+    string live_link = 14;
+}
+
+//
 message SearchLiveInlineCard {
     //
     string title = 1;


### PR DESCRIPTION
**做了什么**

添加了 `SearchLiveRoom` 的定义，并补充 `Item` 类型缺失的 live_room 字段。

**为什么**

目前如果用 SearchByType api 搜索直播相关的内容会无法获取，因为直播间列表会以 `SearchLiveRoom` 而不是 `SearchLiveCard` 显示。