### PR TITLE
fix: 修复获取 wbi 签名的 rust 实现

### DIFF
--- a/docs/misc/sign/wbi.md
+++ b/docs/misc/sign/wbi.md
@@ -120,7 +120,7 @@
 
 ## Demo
 
-含 [Python](#Python)、[JavaScript](#JavaScript)、[Golang](#Golang)、[C#](#CSharp)、[Java](#Java)、[Swift](#Swift)、[C++](#CPlusPlus) 语言编写的 Demo 。
+含 [Python](#Python)、[JavaScript](#JavaScript)、[Golang](#Golang)、[C#](#CSharp)、[Java](#Java)、[Swift](#Swift)、[C++](#CPlusPlus)、[Rust](#Rust) 语言编写的 Demo 。
 
 ### Python
 


### PR DESCRIPTION
在查看 wbi 签名章节时发现 rust 示例和文档表述有不少对不上的地方，这个 PR 修复了这些问题：
1. 获得接口返回的 img_url、sub_url 后未截取文件名就直接使用的错误
2. 未正确截取前 32 位导致的 mixin_key 取值错误
3. 不恰当地使用 fold 方法导致添加了多余尾缀 & 而导致的 encode params 错误

同时，该 PR 添加了相关函数的测试，确保文件名截取、mixin_key 映射与 w_rid 计算结果均与文档描述保持一致。