### PR TITLE
修正docs/live/info.md

### DIFF
--- a/docs/live/info.md
+++ b/docs/live/info.md
@@ -707,7 +707,7 @@ curl -G 'https://api.live.bilibili.com/xlive/web-room/v1/index/getRoomBaseInfo' 
 | room_id             | num | 直播间房间号    | 直播间实际房间号                     |
 | uid                 | num | 主播mid     |                              |
 | online              | num | 直播间在线人数   |                              |
-| live_time           | num | 直播持续时长    |                              |
+| live_time           | num | 开播时间戳，单位秒，未开播时为0    |                              |
 | live_status         | num | 直播间开播状态   | 0：未开播<br />1：正在直播<br />2：轮播中 |
 | short_id            | num | 直播间房间号    | 直播间短房间号，常见于签约主播              |
 | area                | num | 直播间分区id   |                              |


### PR DESCRIPTION
经测试，https://api.live.bilibili.com/room/v1/Room/get_status_info_by_uids中live_time字段应为开播时间戳，单位为秒