### PR TITLE
修复文档网页中，顶部栏“目录”和“首页”都会亮的BUG

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -18,7 +18,6 @@ export default defineUserConfig({
     logo: "/logo2.jpg",
     navbar: [
       { text: "首页", link: "/" },
-      { text: "目录", link: "/#🍴目录" },
       { text: "贡献指南", link: "/CONTRIBUTING.html" },
       {
         text: "相关社群",


### PR DESCRIPTION
如图：
![image](https://github.com/user-attachments/assets/51b441d0-ddb4-42c6-a9ba-c3d414604f56)

如果是为了用户导航方便，其实侧边栏已经有“目录”了

当然，如果有设计上的想法，欢迎指出 @renmu123 

~~最近刚好在研究vuepress，看看我能不能给出什么帮助~~