### PR TITLE
下线两个接口（“检查昵称是否可注册”和“直播间用户实用 API”的直播签到）

### DIFF
--- a/docs/live/user.md
+++ b/docs/live/user.md
@@ -181,7 +181,7 @@ $.ajax({
 
 </details>
 
-## 直播签到
+## ~~直播签到（已下线）~~
 
 > https://api.live.bilibili.com/xlive/web-ucenter/v1/sign/DoSign
 
@@ -199,6 +199,23 @@ _请求方式：GET_
 | ttl     | num  | 1        |                        |
 | message | str  | 错误信息 | 默认为当日签到奖励内容 |
 | data    | obj  | 信息本体 | 默认为空               |
+
+（目前已下线）
+
+<details>
+<summary>查看响应示例（下线后）：</summary>
+
+```json
+{
+    "code": 1,
+    "message": "签到活动已下线，无法使用。",
+    "ttl": 1,
+    "data": null
+}
+```
+
+</details>
+
 
 ## 本月直播签到信息
 

--- a/docs/user/check_nickname.md
+++ b/docs/user/check_nickname.md
@@ -1,6 +1,9 @@
 # 检查昵称是否可注册
 
-## 检查昵称
+## ~~检查昵称（已失效）~~
+
+<details>
+<summary>查看折叠内容</summary>
 
 > https://passport.bilibili.com/web/generic/check/nickname
 
@@ -131,3 +134,12 @@ curl -G 'https://passport.bilibili.com/web/generic/check/nickname' \
 ```
 
 </details>
+
+</details>
+
+目前该接口无论参数，稳定返回：
+```json
+{
+    "code": 0
+}
+```


### PR DESCRIPTION
检查昵称是否可注册的没找到新的可用的接口，现行的方法是直接提交更改，如果不可用就返回特定值；

直播签到是彻底下线了