### PR TITLE
更新直播信息流和开关播的强制需求

### DIFF
--- a/docs/live/manage.md
+++ b/docs/live/manage.md
@@ -274,7 +274,7 @@ curl 'https://api.live.bilibili.com/room/v1/Room/update' \
 | -------- | ---- | ------------------------ | ------ | ----------------------------------- |
 | room_id  | num  | 直播间id                 | 必要   | 必须为自己的直播间id                |
 | area_v2  | num  | 直播分区id（子分区id）   | 必要   | 详见[直播分区](live_area.md)        |
-| platform | str  | 直播平台                 | 必要   | 直播姬（pc）：pc_link<br />web在线直播：web_link（已下线）<br />bililink：android_link |
+| platform | str  | 直播平台                 | 必要   | 直播姬（pc）：pc_link<br />直播姬（android）：android_link |
 | csrf     | str  | CSRF Token（位于cookie） | 必要   |                                     |
 
 **json回复：**
@@ -283,9 +283,9 @@ curl 'https://api.live.bilibili.com/room/v1/Room/update' \
 
 | 字段    | 类型 | 内容     | 备注                                                         |
 | ------- | ---- | -------- | ------------------------------------------------------------ |
-| code    | num  | 返回值   | 0：成功<br />65530：token错误（登录错误）<br />1：错误<br />60009：分区不存在<br />60013：非常抱歉，您所在的地区受实名认证限制无法开播<br />60024: 目标分区需要人脸认证<br />60037: web 在线开播已下线<br />**（其他错误码有待补充）** |
-| msg     | str  | 错误信息 | 默认为空                                                     |
-| message | str  | 错误信息 | 默认为空                                                     |
+| code    | num  | 返回值   | 0：成功<br />65530：token错误（登录错误）<br />1：错误<br />60009：分区不存在<br />60013：非常抱歉，您所在的地区受实名认证限制无法开播<br />60024: 目标分区需要人脸认证<br />60034: 系统维护仅支持直播姬开播<br />60037: web 在线开播已下线<br />**（其他错误码有待补充）** |
+| msg     | str  | 提示信息 | 默认为空                                                     |
+| message | str  | 提示信息 | 默认为空                                                     |
 | data    | obj  | 信息本体 |                                                              |
 
 `data`对象：
@@ -431,7 +431,7 @@ curl 'https://api.live.bilibili.com/room/v1/Room/startLive' \
 
 | 参数名  | 类型 | 内容                     | 必要性 | 备注                 |
 | ------- | ---- | ------------------------ | ------ | -------------------- |
-| platform | str  | 直播平台                 | 必要   | 直播姬（pc）：pc_link<br />web在线直播：web_link（已下线）<br />bililink：android_link |
+| platform | str  | 直播平台                 | 必要   | 直播姬（pc）：pc_link<br />直播姬（android）：android_link |
 | room_id | num  | 直播间id                 | 必要   | 必须为自己的直播间id |
 | csrf    | str  | CSRF Token（位于cookie） | 必要   |                      |
 
@@ -441,9 +441,9 @@ curl 'https://api.live.bilibili.com/room/v1/Room/startLive' \
 
 | 字段    | 类型 | 内容     | 备注                                                         |
 | ------- | ---- | -------- | ------------------------------------------------------------ |
-| code    | num  | 返回值   | 0：成功<br />65530：token错误（登录错误）<br />-400：没有权限<br />**（其他错误码有待补充）** |
-| msg     | str  | 错误信息 | 默认为空                                                     |
-| message | str  | 错误信息 | 默认为空                                                     |
+| code    | num  | 返回值   | 0：成功<br />65530：token错误（登录错误）<br />-400：没有权限<br />60034: 系统维护仅支持直播姬关播<br />**（其他错误码有待补充）** |
+| msg     | str  | 提示信息 | 默认为空                                                     |
+| message | str  | 提示信息 | 默认为空                                                     |
 | data    | obj  | 信息本体 |                                                              |
 
 `data`对象：
@@ -459,6 +459,7 @@ curl 'https://api.live.bilibili.com/room/v1/Room/startLive' \
 
 ```shell
 curl 'https://api.live.bilibili.com/room/v1/Room/stopLive' \
+  --data-urlencode 'platform=pc_link' \
   --data-urlencode 'room_id=10352053' \
   --data-urlencode 'csrf=xxx' \
   -b 'SESSDATA=xxx;bili_jct=xxx'

--- a/docs/live/message_stream.md
+++ b/docs/live/message_stream.md
@@ -8,7 +8,7 @@
 
 认证方式: Cookie(SESSDATA)
 
-鉴权方式：[Wbi 签名](../misc/sign/wbi.md)
+鉴权方式：[Wbi 签名](../misc/sign/wbi.md), Cookie中的`buvid3`不为空
 
 可以选择进行认证，若未认证视作未登录，将会受到限制，详见后续内容。
 
@@ -22,7 +22,7 @@
 | w_rid  | str | Wbi 签名 | 必要  | 详见 [Wbi 签名](../misc/sign/wbi.md) |
 | wts    | num | 当前时间戳  | 必要  | 详见 [Wbi 签名](../misc/sign/wbi.md) |
 
-注: 从2025年5月26日开始正式强制要求Wbi签名。
+注: 从2025年5月26日开始正式强制要求Wbi签名，2025年6月27日开始要求`buvid3`。见[#1295](https://github.com/SocialSisterYi/bilibili-API-collect/issues/1295)
 
 **JSON回复：**
 


### PR DESCRIPTION
## 直播信息流

因为 #1295 有人提出添加Wbi签名也会返回`-352`，后经过测试需要Cookie`buvid3`不为空，所以更新了相关信息。

## 直播间管理

#1319 提出了关闭直播需要`platform`参数。

`web_link`已完全下线，并且与其它值一样返回`60034`，因此删除了它。只在 #1312 做记录。

当重复开关播时，code为`0`但message会有提示，所以描述改为`提示信息`。

更新停止直播的示例。

<details>
<summary>其它信息</summary>

### 开播平台参数需验证

主条目: #1312 

当开播平台为`android_link`和`ios_link`时，按照文档现有参数将会返回`-400`，目前未解决。

</details>