### PR TITLE
添加了来自创作中心的查看注册时间（对于非up主）或首次投稿的时间（对于up主）的api

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ B站 API 采用 C/S 结构，大多数接口为 REST API 和 gRPC，少部分接
     - [x] [用户认证类型一览](docs/user/official_role.md)
     - [ ] [加入老粉计划](docs/user/contract.md)
     - [x] [所有粉丝勋章](docs/user/medals.md)
+    - [x] [注册或首次投稿时间](docs/user/jointime.md)
 - [ ] [大会员](docs/vip)
     - [ ] [大会员基本信息](docs/vip/info.md)
     - [ ] [大会员中心](docs/vip/center.md)

--- a/docs/user/jointime.md
+++ b/docs/user/jointime.md
@@ -1,0 +1,114 @@
+# 查看注册时间（对于非UP主）或首次投稿时间（对于UP主）
+> https://member.bilibili.com/x/web/index/scrolls
+
+*请求方式：get*
+
+认证方式：Cookie(SESSDATA)
+
+**JSON回复**
+
+根对象：
+
+| 字段    | 类型 | 内容     | 备注                          |
+| ------- | ---- | -------- | ----------------------------- |
+| code    | num  | 返回值   | 0: 成功<br />-101: 账号未登录 |
+| message | str  | 错误信息 | 默认为 0                      |
+| ttl     | num  | 1        |                               |
+| data    | obj  | 数据本体 | 失败时不存在                  |
+
+`data` 对象：
+
+`data`中的 `ewcomer` 对象：
+
+| 字段    | 类型 | 内容     | 备注                          |
+| ------- | ---- | -------- | ----------------------------- |
+| medals      | num  | ?   | 作用尚不明确 |
+| no_receive  | num  | ? |  作用尚不明确     |
+| task_received   | num  | ?    |  作用尚不明确  |
+| sub_zero    |  bool  | ? |  作用尚不明确 |
+
+`data` 中的 `scrolls`对象：
+
+| 字段    | 类型 | 内容     | 备注                          |
+| ------- | ---- | -------- | ----------------------------- |
+| id    | num  | ?   |     作用尚不明确 |
+| icon | str | 一张图片的url | 作用尚不明确,图片内容为日历字样        |
+| type     | num  | ?       |            作用尚不明确             |
+| name    | str  | 信息本体 | 若不为up主则返回注册时间，为up主则返回成为up主的时间    |
+| comment | ? | ?  | 作用尚不明确|
+| new | num | ? | 作用尚不明确 |
+| hot | num | ? | 作用尚不明确 |
+| link | url | ? | 提示改页面已废弃|
+
+**请求实例：**
+
+查询自己的注册时间:
+```shell
+curl -G https://member.bilibili.com/x/web/index/scrolls -b 'SESSDATA=xxx'
+```
+
+<details>
+<summary>查看响应示例：</summary>
+
+对于up主：
+
+```json
+{
+  "code": 0,
+  "message": "0",
+  "ttl": 1,
+  "data": {
+    "newcomer": {
+      "medals": 0,
+      "no_receive": 0,
+      "task_received": 0,
+      "sub_zero": false,
+      "tasks": null
+    },
+    "scrolls": [
+      {
+        "id": 0,
+        "icon": "http://i0.hdslb.com/bfs/archive/f58a4b33bbf23464d0aa24210cf97233506e50dc.png",
+        "type": 1,
+        "name": "成为UP主的第29天",
+        "comment": "",
+        "new": 0,
+        "hot": 0,
+        "link": "https://member.bilibili.com/studio/gabriel/creator-calendar/today"
+      }
+    ]
+  }
+}
+```
+
+对于非up主：
+
+```json
+{
+  "code": 0,
+  "message": "0",
+  "ttl": 1,
+  "data": {
+    "newcomer": {
+      "medals": 0,
+      "no_receive": 0,
+      "task_received": 0,
+      "sub_zero": false,
+      "tasks": null
+    },
+    "scrolls": [
+      {
+        "id": 0,
+        "icon": "http://i0.hdslb.com/bfs/archive/f58a4b33bbf23464d0aa24210cf97233506e50dc.png",
+        "type": 1,
+        "name": "加入bilibili星球的第29天",
+        "comment": "",
+        "new": 0,
+        "hot": 0,
+        "link": "https://member.bilibili.com/studio/gabriel/creator-calendar/today"
+      }
+    ]
+  }
+}
+```
+</details>


### PR DESCRIPTION
github新手首次提交的pr....
里面一些内容不太准确，恳请大佬多多包容

起因：自从B站撤销了可以查看注册时间的api（jointime字段恒定返回为0），要查看貌似只有要求归档数据这一个方式，但十分的麻烦。。。在偶然间发现了在创作中心可以看到精度为天的查询方式，用edge浏览器的开发人员工具后找到了api地址，可惜并不能使人人都查到注册时间

还有字段判断我是真的不会，就稍微对比了几个号，发现除了 `data` 里的 `scrlls` 类里的 `name` 字段会变化其他貌似都没有变化www
