### PR TITLE
chore: 修复了`docs/garb/lottery.md`中错误的名称

### DIFF
--- a/docs/garb/lottery.md
+++ b/docs/garb/lottery.md
@@ -1368,7 +1368,7 @@ curl -G --url 'https://api.bilibili.com/x/vas/dlc_act/lottery_home_detail' \
 | squared_image | str | 效果图         |  |
 | static_icon_image | str | 静态图标        |  |
 
-`play_icon` 数组中的对象中 `properties` 对象中的额外字段：
+`skin` 数组中的对象中 `properties` 对象中的额外字段：
 
 | 字段    | 类型  | 内容                  | 备注                   |
 |---------|-----|---------------------|----------------------|


### PR DESCRIPTION
在`“装扮/收藏集”`这个文档的`“主题装扮信息API”`这一章节中，`“play_icon 数组中的对象中 properties 对象中的额外字段：”`这段话，连续出现了两次，但其实第二个应该是`skin` 数组（因为紧跟着的 json 数据对应的是`skin`）而不是`play_icon `数组，名称写错了